### PR TITLE
Update osmium config to include building parts

### DIFF
--- a/osmium.config.json
+++ b/osmium.config.json
@@ -18,6 +18,7 @@
     "aeroway",
     "amenity",
     "building",
+    "building:part",
     "landuse",
     "leisure",
     "man_made",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded area tagging capabilities by adding the "building:part" option. This update provides more granular categorization, enhancing precision when managing area data and improving how mapping details are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->